### PR TITLE
Add Hellen Keller International to the impact calculator

### DIFF
--- a/impact.html
+++ b/impact.html
@@ -427,25 +427,28 @@ t=o.length;t--;)o[t].elem===this&&o[t].queue===e&&(o[t].anim.stop(!0),o.splice(t
   <script type="text/javascript">
 'use strict';
 
-var usdToAudExchangeRate = 0.744;
+var usdToAudExchangeRate = 0.730;
 
 // Against Malaria Foundation (AMF)
-var amfCostPerNetUsd = 4.85;
+var amfCostPerNetUsd = 4.95;
 var amfPeopleProtectedPerNet = 1.8;
-var amfCostPerLifeSavedUsd = 3202.92;
+var amfCostPerLifeSavedUsd = 4450;
 
 // Deworm the World
-var dtwCostPerChildDewormedUsd = 0.55
+var dtwCostPerChildDewormedUsd = 0.5
 
 // Give GiveDirectly
-var gdOverheadPercent = 0.18
-var gdHouseholdYearlyIncomeUsd = 1220
+var gdOverheadPercent = 0.17
+var gdHouseholdYearlyIncomeUsd = 1343.82
 
 // Schistosomiasis Control Initiative (SCI)
-var sciCostPerChildProtectedUsd = 0.49
+var sciCostPerChildProtectedUsd = 0.99
 
 // Malaria Consortium
-var mcCostPerChild = 4.76
+var mcCostPerChild = 7.17
+
+// Helen Keller International
+var hkiCostPerChild = 2.46
 
 // Input
 var DATABASE = {
@@ -603,6 +606,30 @@ var DATABASE = {
           "fraction": "*% of the cost of protecting a child from malaria for 1 year.",
           "single" : "Protect a child from malaria for 1 year.",
           "plural" : "Protect * children from malaria for one year."
+          }
+        }
+      ]
+    },
+    {
+    "name" : "Hellen Keller International",
+    "id" : "hki",
+    "overhead" : 0.000,
+    "infoURL" : "https://effectivealtruism.org.au/charities",
+    "donateURL" : "/donate",
+    "logo" : "e60e",
+    "organization" : buildUrl("https://www.hki.org/", "Hellen Keller International") + " supports government-run vitamin A supplementation (VAS) programs. There is strong evidence that VAS programs reduce child mortality.",
+    "recommendation" : "GiveWell, widely considered the most rigorous charity evaluator in the world, recommends Hellen Keller International as one of their top charities based on their cost-effectiveness and transparency.",
+    "numbers" : "GiveWell estimates " + buildUrl("https://www.givewell.org/charities/helen-keller-international", "it costs AUD 1.10") + " to deliver a vitamin A supplement in HKI-supported programs. This translates to an estimated cost per healthy life saved of AUD 4,016.",
+    "pricePoints" :   [
+        {
+        "price" : hkiCostPerChild,
+        "fractionType": "percent",
+        "iconURL" : "https://raw.githubusercontent.com/RHoKAustralia/effective-altruism-australia/master/Donation%20calculator/img/results/medical.png",
+        "color" : "red",
+        "text" :   {
+          "fraction": "*% of the cost of providing a child with vitamin A supplementation for one year.",
+          "single" : "Provide a child with vitamin A supplementation for one year.",
+          "plural" : "Provide * children with vitamin A supplementation for one year."
           }
         }
       ]


### PR DESCRIPTION
This adds an extra button for HKI following the spec laid out here, as well as updating the price estimates for the other charities:
https://docs.google.com/document/d/1OOWWWuNeVSbHlbCbqEzc871hrMlhV7jyPGIMp2ojm7g/edit

Minor deviation from the script: phrase prices as "AUD x.xx" to match the convention of the other charities, and add hyperlinks to HKI and GiveWell's HKI page.

## Other Notes
- Price estimates come from here: https://docs.google.com/spreadsheets/d/1BmFwVYeGMkpys6hG0tnfHyq__ZFZf-bmXYLSHODGpLY/edit#gid=1070538669
  - We've assumed $0 overhead for HKI (can't see otherwise in the spreadsheet)
  - I calculated the updated GiveDirectly `gdHouseholdYearlyIncomeUsd` by multiplying the "Baseline annual consumption per capita (in nominal USD)" by "Average household size" estimates.
- I can't tell what the `logo` does - seems like nothing, but I just copied the value used for SCI and Malaria Consortium.
- I also can't tell what the `pricePoints` `color` does, but have it as red, which most of the other price points are
  - Andrew Bird also had a look and doesn't think these two attributes do anything
- I also have no idea how this gets deployed or integrated with the rest of the website. It seem to work ok if you just open the HTML file in a web browser, but I'd want to check the other page stylings work as expected.